### PR TITLE
Add optional compilation option for using YAML instead of TOML

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,17 @@ repository = "https://github.com/rust-clique/confy"
 
 [dependencies]
 serde = "1.0"
-toml = "0.4"
+toml = { version = "0.4", optional = true }
 directories = "0.10"
 serde_derive = { version = "1.0", optional = true }
 failure = "0.1"
+serde_yaml = { version = "0.8", optional = true }
 
 [features]
+default = ["toml_conf"]
 sd = ["serde_derive"]
+toml_conf = ["toml"]
+yaml_conf = ["serde_yaml"]
 
 [[example]]
 name = "simple"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,10 @@ edition = "2018"
 serde = "^1.0"
 toml = { version = "^0.5", optional = true }
 directories = "^2.0"
-serde_derive = { version = "1.0", optional = true }
-failure = "0.1"
 serde_yaml = { version = "0.8", optional = true }
-cargo_metadata = "0.8"
 
 [features]
 default = ["toml_conf"]
-sd = ["serde_derive"]
 toml_conf = ["toml"]
 yaml_conf = ["serde_yaml"]
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ fn main() -> Result<(), ::std::io::Error> {
     dbg!(cfg);
     Ok(())
 }
+```
 
 Enabling the `yaml_conf` feature while disabling the default `toml_conf`
 feature causes confy to use a YAML config file instead of TOML.

--- a/README.md
+++ b/README.md
@@ -24,4 +24,13 @@ fn main() -> Result<(), ::std::io::Error> {
 }
 ```
 
+## Features
 
+Enabling the `yaml_conf` feature while disabling the default `toml_conf`
+feature causes confy to use a YAML config file instead of TOML.
+
+```
+[dependencies.confy]
+features = ["yaml_conf"]
+default-features = false
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ impl std::error::Error for ConfyError {}
 */
 
 #[cfg(not(any(feature = "toml_conf", feature = "yaml_conf")))]
-compile_error!("Exactly one markup language feature must be enabled to use \
+compile_error!("Exactly one config language feature must be enabled to use \
 confy.  Please enable one of either the `toml_conf` or `yaml_conf` \
 features.");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub enum ConfyError {
 const EXTENSION: &str = "toml";
 
 #[cfg(feature = "yaml_conf")]
-const EXTENSION: &str = "yaml";
+const EXTENSION: &str = "yml";
 
 /// Load an application configuration from disk
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,13 @@ compile_error!("Exactly one config language feature must be enabled to use \
 confy.  Please enable one of either the `toml_conf` or `yaml_conf` \
 features.");
 
-#[cfg(feature = "toml_conf")]
+#[cfg(all(feature = "toml_conf", feature = "yaml_conf"))]
+compile_error!("Exactly one config language feature must be enabled to compile \
+confy.  Please disable one of either the `toml_conf` or `yaml_conf` features. \
+NOTE: `toml_conf` is a default feature, so disabling it might mean switching off \
+default features for confy in your Cargo.toml");
+
+#[cfg(all(feature = "toml_conf", not(feature = "yaml_conf")))]
 const EXTENSION: &str = "toml";
 
 #[cfg(feature = "yaml_conf")]


### PR DESCRIPTION
As I'm sure you know, [YAML](https://yaml.org/) is a human readable data format very popular for making config files.  So popular, in fact, that [people have already forked this repository to completely replace TOML with YAML](https://github.com/GoWebProd/confy/commit/8a0005256430d5d6b1fc04db9d5e77ba54a7513d).  While replacing TOML with YAML completely on the master branch would probably be a very bad idea, adding it as a compilation option while leaving TOML as the default seems to be a win-win, and will not break compatibility with dependants' config files, (being opt in).

This implementation creates a couple new errors for YAML types with a different name than TOML errors, since renaming TOML errors to a generic name would be a breaking change.  However, perhaps next major version bump, `BadTomlData` and `BadYamlData` could be merged into `DeserializeError` or something similar, while `SerializeTomlError` and `SerializeYamlError` could be merged into something like `SerializeError`.  This would make someone who already uses TOML's transition to YAML easier, or vice versa.

This implementation also doesn't tolerate having both TOML and YAML, or neither TOML and YAML enabled at once.