### PR TITLE
Updated confy with the ability to use the crate name in the directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confy"
-version = "0.3.2-alpha.0"
+version = "0.3.2-alpha.1"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 description = "Boilerplate-free configuration management"
 license = "MIT/X11 OR Apache-2.0"
@@ -13,6 +13,7 @@ toml = "0.4"
 directories = "0.10"
 serde_derive = { version = "1.0", optional = true }
 failure = "0.1"
+cargo_metadata = "0.8"
 
 [features]
 sd = ["serde_derive"]


### PR DESCRIPTION
This PR updates the naming convention of the config folder in `$XDG_CONFIG_HOME` with the naming scheme `rs.$CRATE_NAME.$CONFIG_NAME` instead of `rs.$CONFIG_NAME.$CONFIG_NAME` which will help create less overwrites if saving multiple configs with say a username. 

This PR added the cargo_metadata dependency and included mapping error messages
back to `ConfyError`.