### PR TITLE
Clean dependencies, fix cross compilation, fix runtime cargo-manifest bug, change from failure to std::error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ serde = "1.0"
 toml = "0.4"
 directories = "0.10"
 serde_derive = { version = "1.0", optional = true }
-failure = "0.1"
 cargo_metadata = "0.8"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,12 @@ documentation = "https://docs.rs/confy"
 repository = "https://github.com/rust-clique/confy"
 
 [dependencies]
-serde = "1.0"
-toml = "0.4"
-directories = "0.10"
-serde_derive = { version = "1.0", optional = true }
-
-[features]
-sd = ["serde_derive"]
+serde = "^1.0"
+toml = "^0.5"
+directories = "^2.0"
 
 [[example]]
 name = "simple"
-required-features = ["sd"]
+
+[dev-dependencies]
+serde_derive = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ serde = "1.0"
 toml = "0.4"
 directories = "0.10"
 serde_derive = { version = "1.0", optional = true }
-cargo_metadata = "0.8"
 
 [features]
 sd = ["serde_derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,53 +62,52 @@ extern crate cargo_metadata;
 extern crate directories;
 extern crate serde;
 extern crate toml;
-#[macro_use]
-extern crate failure;
 
 mod utils;
 use utils::*;
 
 use directories::ProjectDirs;
 use serde::{de::DeserializeOwned, Serialize};
+use std::error::Error;
+use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::{ErrorKind::NotFound, Write};
 use std::path::PathBuf;
 
-#[derive(Debug, Fail)]
+#[derive(Debug)]
 pub enum ConfyError {
-    #[fail(display = "Bad TOML data: {}", _0)]
     BadTomlData(toml::de::Error),
-
-    #[fail(display = "Failed to create directory: {}", _0)]
     DirectoryCreationFailed(std::io::Error),
-
-    #[fail(display = "Failed to load configuration file.")]
     GeneralLoadError(std::io::Error),
-
-    #[fail(display = "Failed to convert directory name to str.")]
     BadConfigDirectoryStr,
-
-    #[fail(display = "Failed to serialize configuration data into TOML.")]
     SerializeTomlError(toml::ser::Error),
-
-    #[fail(display = "Failed to write configuration file.")]
     WriteConfigurationFileError(std::io::Error),
-
-    #[fail(display = "Failed to read configuration file.")]
     ReadConfigurationFileError(std::io::Error),
-
-    #[fail(display = "Failed to open configuration file.")]
     OpenConfigurationFileError(std::io::Error),
-
-    #[fail(display = "Failed to get cargo metadata.")]
     CargoMetadataExecError(cargo_metadata::Error),
-
-    #[fail(display = "Failed to get crate's dependency graph.")]
     CargoMetadataResolveError,
-
-    #[fail(display = "Failed to get crate's root dependency.")]
     CargoMetadataRootError,
 }
+
+impl fmt::Display for ConfyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ConfyError::BadTomlData(e) => write!(f, "Bad TOML data: {}", e),
+            ConfyError::DirectoryCreationFailed(e) => write!(f, "Failed to create directory: {}", e),
+            ConfyError::GeneralLoadError(_) => write!(f, "Failed to load configuration file."),
+            ConfyError::BadConfigDirectoryStr => write!(f, "Failed to convert directory name to str."),
+            ConfyError::SerializeTomlError(_) => write!(f, "Failed to serialize configuration data into TOML."),
+            ConfyError::WriteConfigurationFileError(_) => write!(f, "Failed to write configuration file."),
+            ConfyError::ReadConfigurationFileError(_) => write!(f, "Failed to read configuration file."),
+            ConfyError::OpenConfigurationFileError(_) => write!(f, "Failed to open configuration file."),
+            ConfyError::CargoMetadataExecError(_) => write!(f, "Failed to get cargo metadata."),
+            ConfyError::CargoMetadataResolveError => write!(f, "Failed to get crate's dependency graph."),
+            ConfyError::CargoMetadataRootError => write!(f, "Failed to get crate's root dependency."),
+        }
+    }
+}
+
+impl Error for ConfyError {}
 
 /// Load an application configuration from disk
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ impl Error for ConfyError {}
 /// # impl ::std::default::Default for MyConf {
 /// #     fn default() -> Self { Self {} }
 /// # }
-/// let cfg: MyConfig = confy::load("my-app")?;
+/// let cfg: MyConfig = confy::load("my-app-name")?;
 /// ```
 pub fn load<T: Serialize + DeserializeOwned + Default>(name: &str) -> Result<T, ConfyError> {
     let root_name = get_root_name()?;
@@ -171,7 +171,7 @@ pub fn load<T: Serialize + DeserializeOwned + Default>(name: &str) -> Result<T, 
 /// ```rust,no_run
 /// # struct MyConf {}
 /// let my_cfg = MyConf {};
-/// confy::store(my_cfg)?;
+/// confy::store("my-app-name", my_cfg)?;
 /// ```
 ///
 /// Errors returned are I/O errors related to not being

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ impl Error for ConfyError {}
 /// let cfg: MyConfig = confy::load("my-app-name")?;
 /// ```
 pub fn load<T: Serialize + DeserializeOwned + Default>(name: &str) -> Result<T, ConfyError> {
-    let project = ProjectDirs::from("rs", "", name);
+    let project = ProjectDirs::from("rs", "", name).ok_or(ConfyError::BadConfigDirectoryStr)?;
 
     let config_dir_str = get_configuration_directory_str(&project)?;
 
@@ -170,7 +170,7 @@ pub fn load<T: Serialize + DeserializeOwned + Default>(name: &str) -> Result<T, 
 /// encounters an operating system or environment it does
 /// not support.
 pub fn store<T: Serialize>(name: &str, cfg: T) -> Result<(), ConfyError> {
-    let project = ProjectDirs::from("rs", "", name);
+    let project = ProjectDirs::from("rs", "", name).ok_or(ConfyError::BadConfigDirectoryStr)?;
     fs::create_dir_all(project.config_dir()).map_err(ConfyError::DirectoryCreationFailed)?;
 
     let config_dir_str = get_configuration_directory_str(&project)?;


### PR DESCRIPTION
This also fixes a few typos in the examples.

Overall, this fixes #23, #24, and bumps the library to use new versions of all of it's dependencies.

It now works outside of cargo directories (binaries produced before this fix would crash at runtime if executed outside of a project directory — essentially rendering the library unusable). My solution was to just use an empty organization string, if someone has a better suggestion, please let me know, but the cargo-manifest solution from before was a lot of code that duplicated the user-provided string and broke at runtime.

This also cross-compiles to macOS and the number of dependencies pulled in by this library was cut in third. 