### PR TITLE
Improve clarity in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ Chat with us: [Discord](https://discord.gg/dwq4Zme)
 
 Zero-boilerplate configuration management.
 
-Focus on storing the right data, 
-instead of worrying about how to store it.
+Focus on storing the right data, instead of worrying about how or where to store it.
 
 ```rust
-#[macro_use]
-extern crate serde_derive;
+use serde_derive::{Serialize, Deserialize};
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 struct MyConfig {
@@ -24,6 +22,7 @@ fn main() -> Result<(), ::std::io::Error> {
 }
 ```
 
+## Using yaml
 Enabling the `yaml_conf` feature while disabling the default `toml_conf`
 feature causes confy to use a YAML config file instead of TOML.
 
@@ -32,3 +31,9 @@ feature causes confy to use a YAML config file instead of TOML.
 features = ["yaml_conf"]
 default-features = false
 ```
+
+## Breakings changes
+Starting with version 0.4.0 the configuration file are stored in the expected place for your system. See the [`directories`] crates for more information.
+Before version 0.4.0, the configuration file was written in the current directory.
+
+[`directories`]: https://crates.io/crates/directories

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! [`Default`]: https://doc.rust-lang.org/std/default/trait.Default.html
 //!
 //! ```rust,no_run
-//! # use serde_derive::{Serialize, Deserialize};
+//! use serde_derive::{Serialize, Deserialize};
 //!
 //! #[derive(Serialize, Deserialize)]
 //! struct MyConfig {
@@ -107,11 +107,9 @@ const EXTENSION: &str = "yml";
 /// # use confy::ConfyError;
 /// # use serde_derive::{Serialize, Deserialize};
 /// # fn main() -> Result<(), ConfyError> {
-/// #[derive(Serialize, Deserialize)]
+/// #[derive(Default, Serialize, Deserialize)]
 /// struct MyConfig {}
-/// # impl ::std::default::Default for MyConfig {
-/// #     fn default() -> Self { Self {} }
-/// # }
+///
 /// let cfg: MyConfig = confy::load("my-app-name")?;
 /// # Ok(())
 /// # }
@@ -162,6 +160,7 @@ pub fn load_path<T: Serialize + DeserializeOwned + Default>(path: impl AsRef<Pat
     }
 }
 
+/// The errors the confy crate can encounter.
 #[derive(Debug)]
 pub enum ConfyError {
     #[cfg(feature = "toml_conf")]
@@ -226,8 +225,9 @@ impl Error for ConfyError {}
 /// # use serde_derive::{Serialize, Deserialize};
 /// # use confy::ConfyError;
 /// # fn main() -> Result<(), ConfyError> {
-/// # #[derive(Serialize, Deserialize)]
-/// # struct MyConf {}
+/// #[derive(Serialize, Deserialize)]
+/// struct MyConf {}
+///
 /// let my_cfg = MyConf {};
 /// confy::store("my-app-name", my_cfg)?;
 /// # Ok(())


### PR DESCRIPTION
Do not hide the need for serde in the documentation.
Add a little changelog for end user breaking changes.