### PR TITLE
Call default() only once on load

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,8 +153,9 @@ pub fn load_path<T: Serialize + DeserializeOwned + Default>(path: impl AsRef<Pat
                 fs::create_dir_all(parent)
                     .map_err(ConfyError::DirectoryCreationFailed)?;
             }
-            store_path(path, T::default())?;
-            Ok(T::default())
+            let cfg = T::default();
+            store_path(path, &cfg)?;
+            Ok(cfg)
         }
         Err(e) => Err(ConfyError::GeneralLoadError(e)),
     }


### PR DESCRIPTION
Currently when calling confy::load or confy::load_path, inside the load_path function the configuration struct's default method is called twice. This may be unwanted for some reasons:

- the defaults are fetched from a remote server,
- the defaults are a result of a long running calculation,
- there are no reasonable defaults and thus user is prompted for input.

I agree that the Default trait maybe shouldn't bother with such cases, but anyhow it seems unnecessary to call default() twice.

This pull request introduces a minor change, i.e. in the load_path function a local variable is set by calling default() once, then a reference is passed to the store() function and the variable is returned to the caller.