### PR TITLE
Update dependencies fix #38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/rust-clique/confy"
 edition = "2018"
 
 [dependencies]
+directories-next = "^2.0"
 serde = "^1.0"
-toml = { version = "^0.5", optional = true }
-directories = "^2.0"
 serde_yaml = { version = "0.8", optional = true }
+toml = { version = "^0.5", optional = true }
 
 [features]
 default = ["toml_conf"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 mod utils;
 use utils::*;
 
-use directories::ProjectDirs;
+use directories_next::ProjectDirs;
 use serde::{de::DeserializeOwned, Serialize};
 use std::error::Error;
 use std::fmt;


### PR DESCRIPTION
I updated to use the last version of `directories-next` (formerly using `directories`).

Also as I understand `directories` from the version 2 to 3 and `directories-next` from version 1 to 2 have both breaking changes regarding macos.
I don't use macos so I am not sure to understand everything happening here (2 times the same change or opposites ones ?). Should we prevent users of `confy` ? How is it done usually ?