### PR TITLE
fix doc-tests and store functionality

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -5,6 +5,9 @@ extern crate confy;
 #[macro_use]
 extern crate serde_derive;
 
+use std::io::Read;
+use confy::ConfyError;
+
 #[derive(Debug, Serialize, Deserialize)]
 struct ConfyConfig {
     name: String,
@@ -28,5 +31,27 @@ fn main() -> Result<(), confy::ConfyError> {
     println!("The configuration file path is: {:#?}", file);
     println!("The configuration is:");
     println!("{:#?}", cfg);
+    println!("The wrote toml file content is:");
+    let mut content = String::new();
+    std::fs::File::open(&file)
+        .expect("Failed to read toml configuration file.")
+        .read_to_string(&mut content);
+    println!("{}", content);
+    let cfg = ConfyConfig {
+        name: "Test".to_string(),
+        ..cfg
+    };
+    confy::store("confy_simple_app",None, &cfg)?;
+    println!("The updated toml file content is:");
+    let mut content = String::new();
+    std::fs::File::open(&file)
+        .expect("Failed to read toml configuration file.")
+        .read_to_string(&mut content);
+    println!("{}", content);
+    let cfg = ConfyConfig {
+        name: "Test".to_string(),
+        ..cfg
+    };
+    std::fs::remove_dir_all(file.parent().unwrap());
     Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,7 +6,6 @@ extern crate confy;
 extern crate serde_derive;
 
 use std::io::Read;
-use confy::ConfyError;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ConfyConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ pub fn store<'a, T: Serialize>(
     cfg: T,
 ) -> Result<(), ConfyError> {
     let path = get_configuration_file_path(app_name, config_name)?;
-    fs::create_dir_all(&path).map_err(ConfyError::DirectoryCreationFailed)?;
+    fs::create_dir_all(&path.parent().unwrap()).map_err(ConfyError::DirectoryCreationFailed)?;
 
     store_path(path, cfg)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! }
 //!
 //! fn main() -> Result<(), confy::ConfyError> {
-//!     let cfg = confy::load("my-app-name")?;
+//!     let cfg = confy::load("my-app-name", None)?;
 //!     Ok(())
 //! }
 //! ```


### PR DESCRIPTION
A doc-tests code hasn't been updated. Update this to pass the `cargo test`
And store function mistakenly try to create config.toml as a directory so that every attempt to store updated configuration file would fail.
Also made some changes to example/simple.rs