### PR TITLE
Change store_path() to not clear on-disk file if serialization fails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ name = "simple"
 
 [dev-dependencies]
 serde_derive = "^1.0"
+tempfile = "3.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,13 +279,6 @@ pub fn store<'a, T: Serialize>(
 ///
 /// [`store`]: fn.store.html
 pub fn store_path<T: Serialize>(path: impl AsRef<Path>, cfg: T) -> Result<(), ConfyError> {
-    let mut f = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(path)
-        .map_err(ConfyError::OpenConfigurationFileError)?;
-
     let s;
     #[cfg(feature = "toml_conf")]
     {
@@ -295,6 +288,13 @@ pub fn store_path<T: Serialize>(path: impl AsRef<Path>, cfg: T) -> Result<(), Co
     {
         s = serde_yaml::to_string(&cfg).map_err(ConfyError::SerializeYamlError)?;
     }
+
+    let mut f = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .map_err(ConfyError::OpenConfigurationFileError)?;
 
     f.write_all(s.as_bytes())
         .map_err(ConfyError::WriteConfigurationFileError)?;


### PR DESCRIPTION
Partly resolves #47.

I think this would benefit from a unit test to ensure that a failed serialization doesn't overwrite the file.