### PR TITLE
Generic format

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -25,8 +25,8 @@ impl Default for ConfyConfig {
 }
 
 fn main() -> Result<(), confy::ConfyError> {
-    let cfg: ConfyConfig = confy::load("confy_simple_app", None)?;
-    let file = confy::get_configuration_file_path("confy_simple_app", None)?;
+    let cfg: ConfyConfig = confy::load::<confy::Toml, _, _>("confy_simple_app", None)?;
+    let file = confy::get_configuration_file_path::<confy::Toml, _>("confy_simple_app", None)?;
     println!("The configuration file path is: {:#?}", file);
     println!("The configuration is:");
     println!("{:#?}", cfg);
@@ -41,7 +41,7 @@ fn main() -> Result<(), confy::ConfyError> {
         name: "Test".to_string(),
         ..cfg
     };
-    confy::store("confy_simple_app",None, &cfg)?;
+    confy::store::<confy::Toml, _, _>("confy_simple_app",None, &cfg)?;
     println!("The updated toml file content is:");
     let mut content = String::new();
     std::fs::File::open(&file)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,9 +185,7 @@ pub fn load<'a, T: Serialize + DeserializeOwned + Default>(
     app_name: &str,
     config_name: impl Into<Option<&'a str>>,
 ) -> Result<T, ConfyError> {
-    let path = get_configuration_file_path(app_name, config_name)?;
-
-    load_path(path)
+    get_configuration_file_path(app_name, config_name).and_then(load_path)
 }
 
 /// Load an application configuration from a specified path.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,14 +79,6 @@ confy.  Please enable one of either the `toml_conf` or `yaml_conf` \
 features."
 );
 
-#[cfg(all(feature = "toml_conf", feature = "yaml_conf"))]
-compile_error!(
-    "Exactly one config language feature must be enabled to compile \
-confy.  Please disable one of either the `toml_conf` or `yaml_conf` features. \
-NOTE: `toml_conf` is a default feature, so disabling it might mean switching off \
-default features for confy in your Cargo.toml"
-);
-
 pub trait Format {
     fn extension() -> &'static str;
 


### PR DESCRIPTION
This PR adds a generic type parameter to specify the deserialization format.

This PR is not ready yet, and - maybe more importantly - is a draft because I just want to propose this. I'm not 100% happy with how the API looks!

Lets discuss whether something like this is an idea. Maybe we could change the API so that not a generic argument is passed, but an actual object, to make the API a bit easier to use...?

---

This includes #49 