### PR TITLE
Revert "Add config file location info to the documentation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ fn main() -> Result<(), ::std::io::Error> {
 }
 ```
 
-Configuration files are stored in the expected place
-for your system. See the [directories] crate for more
-information.
-
-[directories]: https://docs.rs/directories
-
 ## Using yaml
 Enabling the `yaml_conf` feature while disabling the default `toml_conf`
 feature causes confy to use a YAML config file instead of TOML.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,12 +60,6 @@
 //!
 //! [`store`]: fn.store.html
 //!
-//! Configuration files are stored in the expected place
-//! for your system. See the [directories] crate for more
-//! information.
-//!
-//! [directories]: https://docs.rs/directories
-//!
 
 mod utils;
 use utils::*;


### PR DESCRIPTION
Reverts rust-cli/confy#54

Meh, sorry, I didn't read the comment in #54 carefully enough.