### PR TITLE
feat: use thiserror, and chain source errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 directories-next = "^2.0"
 serde = "^1.0"
 serde_yaml = { version = "0.8", optional = true }
+thiserror = "1.0"
 toml = { version = "^0.5", optional = true }
 
 [features]


### PR DESCRIPTION
This mostly preserves the same messages as before, but uses the `#[source]` attribute of `thiserror` to identify the underlying cause, which improves the reporting of error chains.

For example, with `anyhow`'s default reporting:

**Before**

```
Error: Crashed

Caused by:
    Failed to load configuration file.
```

**After**

```
Error: Crashed

Caused by:
    0: Failed to load configuration file
    1: Permission denied (os error 13)
```