### PR TITLE
fix: `store_path` should create missing directories, like `load_path`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,12 +297,10 @@ pub fn get_configuration_file_path<'a>(
 }
 
 fn get_configuration_directory_str(project: &ProjectDirs) -> Result<&str, ConfyError> {
-    let config_dir_option = project.config_dir().to_str();
-
-    match config_dir_option {
-        Some(x) => Ok(x),
-        None => Err(ConfyError::BadConfigDirectoryStr),
-    }
+    project
+        .config_dir()
+        .to_str()
+        .ok_or(ConfyError::BadConfigDirectoryStr)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,8 +238,6 @@ pub fn store<'a, T: Serialize>(
     cfg: T,
 ) -> Result<(), ConfyError> {
     let path = get_configuration_file_path(app_name, config_name)?;
-    fs::create_dir_all(&path.parent().unwrap()).map_err(ConfyError::DirectoryCreationFailed)?;
-
     store_path(path, cfg)
 }
 
@@ -251,6 +249,9 @@ pub fn store<'a, T: Serialize>(
 ///
 /// [`store`]: fn.store.html
 pub fn store_path<T: Serialize>(path: impl AsRef<Path>, cfg: T) -> Result<(), ConfyError> {
+    let path = path.as_ref();
+    fs::create_dir_all(path.parent().unwrap()).map_err(ConfyError::DirectoryCreationFailed)?;
+
     let s;
     #[cfg(feature = "toml_conf")]
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ mod tests {
     /// Verify that if you call store_path() with an object that fails to serialize,
     /// the file on disk will not be overwritten or truncated.
     #[test]
-    fn test_store_path() -> Result<(), ConfyError> {
+    fn test_store_path_atomic() -> Result<(), ConfyError> {
         let tmp = tempfile::NamedTempFile::new().expect("Failed to create NamedTempFile");
         let path = tmp.path();
         let message = "Hello world!";


### PR DESCRIPTION
Currently, `load`, `load_path`, and `store` will create any missing parent directories in the config file path, but `store_path` won't.

This adds some test coverage, and moves the `create_dir_all` call from `store` into `store_path`, which should fix the issue and align the behaviour of all four functions.