### PR TITLE
Prepare for 0.5.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "confy"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 description = "Boilerplate-free configuration management"
 license = "MIT/X11 OR Apache-2.0"
 documentation = "https://docs.rs/confy"
 repository = "https://github.com/rust-cli/confy"
+readme = "README.md"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
This MR bumps the version number and fix link to repository for [crates.io](https://crates.io/crates/confy) to load the `README` and other links correctly. 

Since this is a breaking version I'd like to discussion around #64 resolved first to see if we can ship less breaking changes with `0.5.0`.