### PR TITLE
Revert to use directories instead of directories-next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rust-cli/confy"
 edition = "2018"
 
 [dependencies]
-directories-next = "^2.0"
+directories = "^2.0"
 serde = "^1.0"
 serde_yaml = { version = "0.8", optional = true }
 thiserror = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 mod utils;
 use utils::*;
 
-use directories_next::ProjectDirs;
+use directories::ProjectDirs;
 use serde::{de::DeserializeOwned, Serialize};
 use std::fs::{self, File, OpenOptions};
 use std::io::{ErrorKind::NotFound, Write};


### PR DESCRIPTION
Closes #64 

I just had a quick look but the patch that replaced `directories` (from #38) unfortunately contains more than just that and thus cannot be reverted.

This patch _does not_ update the crate.