### PR TITLE
Adding `ron` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/X11 OR Apache-2.0"
 documentation = "https://docs.rs/confy"
 repository = "https://github.com/rust-cli/confy"
 readme = "README.md"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 ron = { version = "0.8.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,11 @@ license = "MIT/X11 OR Apache-2.0"
 documentation = "https://docs.rs/confy"
 repository = "https://github.com/rust-cli/confy"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 directories = "^2.0"
+ron = { version = "0.8.0", optional = true }
 serde = "^1.0"
 serde_yaml = { version = "0.8", optional = true }
 thiserror = "1.0"
@@ -20,6 +21,7 @@ toml = { version = "^0.5", optional = true }
 default = ["toml_conf"]
 toml_conf = ["toml"]
 yaml_conf = ["serde_yaml"]
+ron_conf = ["ron"]
 
 [[example]]
 name = "simple"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ features = ["yaml_conf"]
 default-features = false
 ```
 
+## Using ron
+This works in the same way as using yaml. So enable the `ron_conf` feature
+flag and disable `toml_conf` to make confy use RON config files instead of TOML.
+
+```
+[dependencies.confy]
+features = ["ron_conf"]
+default-features = false
+```
+
 ## Breaking changes
 ### Version 0.5.0
 * The base functions `load` and `store` have been added an optional parameter in the event multiples configurations are needed, or ones with different filename.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ fn main() -> Result<(), ::std::io::Error> {
 ## Confy's feature flags
 Confy can be used with either `TOML`, `YAML`, or `RON` files.
 `TOML` is the default language used with confy but any of the other languages can be used by enabling them with feature flags as shown below.
-Note that you can only use __one__ of these features at a time, so in order to use either of the optional features you have to disable default features.
+
+Note: you can only use __one__ of these features at a time, so in order to use either of the optional features you have to disable default features.
 
 ### Using yaml
 To use YAML files with confy you have to make sure you have enabled the `yaml_conf` feature and disabled both `toml_conf` and `ron_conf`.

--- a/README.md
+++ b/README.md
@@ -24,21 +24,26 @@ fn main() -> Result<(), ::std::io::Error> {
 }
 ```
 
-## Using yaml
-Enabling the `yaml_conf` feature while disabling the default `toml_conf`
-feature causes confy to use a YAML config file instead of TOML.
+## Confy's feature flags
+Confy can be used with either `TOML`, `YAML`, or `RON` files.
+`TOML` is the default language used with confy but any of the other languages can be used by enabling them with feature flags as shown below.
+Note that you can only use __one__ of these features at a time, so in order to use either of the optional features you have to disable default features.
 
-```
+### Using yaml
+To use YAML files with confy you have to make sure you have enabled the `yaml_conf` feature and disabled both `toml_conf` and `ron_conf`.
+
+Enable the feature in `Cargo.toml`:
+```toml
 [dependencies.confy]
 features = ["yaml_conf"]
 default-features = false
 ```
 
-## Using ron
-This works in the same way as using yaml. So enable the `ron_conf` feature
-flag and disable `toml_conf` to make confy use RON config files instead of TOML.
+### Using ron
+For using RON files with confy you have to make sure you have enabled the `ron_conf` feature and disabled both `toml_conf` and `yaml_conf`.
 
-```
+Enable the feature in `Cargo.toml`:
+```toml
 [dependencies.confy]
 features = ["ron_conf"]
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,14 +74,14 @@ use thiserror::Error;
 #[cfg(not(any(feature = "toml_conf", feature = "yaml_conf", feature = "ron_conf")))]
 compile_error!(
     "Exactly one config language feature must be enabled to use \
-confy.  Please enable one of either the `toml_conf`, `yaml_conf` \
+confy.  Please enable one of either the `toml_conf`, `yaml_conf`, \
 or `ron_conf` features."
 );
 
 #[cfg(all(feature = "toml_conf", feature = "yaml_conf", feature = "ron_conf"))]
 compile_error!(
     "Exactly one config language feature must be enabled to compile \
-confy.  Please disable one of either the `toml_conf`, `yaml_conf` or `ron_conf` features. \
+confy.  Please disable one of either the `toml_conf`, `yaml_conf`, or `ron_conf` features. \
 NOTE: `toml_conf` is a default feature, so disabling it might mean switching off \
 default features for confy in your Cargo.toml"
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,7 @@ mod tests {
     // Verify that [`load_path`] can deserialize into structs with differing names
     // as long as they have the same fields
     #[test]
-    fn test_ron_change_struct_name() -> Result<(), ConfyError> {
+    fn test_change_struct_name() -> Result<(), ConfyError> {
         with_config_path(|path| {
             #[derive(PartialEq, Default, Debug, Serialize, Deserialize)]
             struct AnotherExampleConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,11 @@ confy.  Please enable one of either the `toml_conf`, `yaml_conf`, \
 or `ron_conf` features."
 );
 
-#[cfg(all(feature = "toml_conf", feature = "yaml_conf", feature = "ron_conf"))]
+#[cfg(any(
+    all(feature = "toml_conf", feature = "yaml_conf"),
+    all(feature = "toml_conf", feature = "ron_conf"),
+    all(feature = "ron_conf", feature = "yaml_conf"),
+))]
 compile_error!(
     "Exactly one config language feature must be enabled to compile \
 confy.  Please disable one of either the `toml_conf`, `yaml_conf`, or `ron_conf` features. \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,8 @@ pub fn store_path<T: Serialize>(path: impl AsRef<Path>, cfg: T) -> Result<(), Co
     }
     #[cfg(feature = "ron_conf")]
     {
-        s = ron::to_string(&cfg).map_err(ConfyError::SerializeRonError)?;
+        let pretty_cfg = ron::ser::PrettyConfig::default().struct_names(true);
+        s = ron::ser::to_string_pretty(&cfg, pretty_cfg).map_err(ConfyError::SerializeRonError)?;
     }
 
     let mut f = OpenOptions::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ pub fn store_path<T: Serialize>(path: impl AsRef<Path>, cfg: T) -> Result<(), Co
     }
     #[cfg(feature = "ron_conf")]
     {
-        let pretty_cfg = ron::ser::PrettyConfig::default().struct_names(true);
+        let pretty_cfg = ron::ser::PrettyConfig::default();
         s = ron::ser::to_string_pretty(&cfg, pretty_cfg).map_err(ConfyError::SerializeRonError)?;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,4 +448,22 @@ mod tests {
         assert_eq!(buf, message);
         Ok(())
     }
+
+    // Verify that [`load_path`] can deserialize into structs with differing names
+    // as long as they have the same fields
+    #[test]
+    fn test_ron_change_struct_name() -> Result<(), ConfyError> {
+        with_config_path(|path| {
+            #[derive(PartialEq, Default, Debug, Serialize, Deserialize)]
+            struct AnotherExampleConfig {
+                name: String,
+                count: usize,
+            }
+
+            store_path(path, &ExampleConfig::default()).expect("store_path failed");
+            let _: AnotherExampleConfig = load_path(path).expect("load_path failed");
+        });
+
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,17 +195,17 @@ pub fn load_path<T: Serialize + DeserializeOwned + Default>(
             #[cfg(feature = "toml_conf")]
             {
                 let cfg_data = toml::from_str(&cfg_string);
-                return cfg_data.map_err(ConfyError::BadTomlData);
+                cfg_data.map_err(ConfyError::BadTomlData)
             }
             #[cfg(feature = "yaml_conf")]
             {
                 let cfg_data = serde_yaml::from_str(&cfg_string);
-                return cfg_data.map_err(ConfyError::BadYamlData);
+                cfg_data.map_err(ConfyError::BadYamlData)
             }
             #[cfg(feature = "ron_conf")]
             {
                 let cfg_data = ron::from_str(&cfg_string);
-                return cfg_data.map_err(ConfyError::BadRonData);
+                cfg_data.map_err(ConfyError::BadRonData)
             }
         }
         Err(ref e) if e.kind() == NotFound => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,17 +71,17 @@ use std::io::{ErrorKind::NotFound, Write};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
-#[cfg(not(any(feature = "toml_conf", feature = "yaml_conf")))]
+#[cfg(not(any(feature = "toml_conf", feature = "yaml_conf", feature = "ron_conf")))]
 compile_error!(
     "Exactly one config language feature must be enabled to use \
-confy.  Please enable one of either the `toml_conf` or `yaml_conf` \
-features."
+confy.  Please enable one of either the `toml_conf`, `yaml_conf` \
+or `ron_conf` features."
 );
 
-#[cfg(all(feature = "toml_conf", feature = "yaml_conf"))]
+#[cfg(all(feature = "toml_conf", feature = "yaml_conf", feature = "ron_conf"))]
 compile_error!(
     "Exactly one config language feature must be enabled to compile \
-confy.  Please disable one of either the `toml_conf` or `yaml_conf` features. \
+confy.  Please disable one of either the `toml_conf`, `yaml_conf` or `ron_conf` features. \
 NOTE: `toml_conf` is a default feature, so disabling it might mean switching off \
 default features for confy in your Cargo.toml"
 );
@@ -91,6 +91,9 @@ const EXTENSION: &str = "toml";
 
 #[cfg(feature = "yaml_conf")]
 const EXTENSION: &str = "yml";
+
+#[cfg(feature = "ron_conf")]
+const EXTENSION: &str = "ron";
 
 /// The errors the confy crate can encounter.
 #[derive(Debug, Error)]
@@ -102,6 +105,10 @@ pub enum ConfyError {
     #[cfg(feature = "yaml_conf")]
     #[error("Bad YAML data")]
     BadYamlData(#[source] serde_yaml::Error),
+
+    #[cfg(feature = "ron_conf")]
+    #[error("Bad RON data")]
+    BadRonData(#[source] ron::error::SpannedError),
 
     #[error("Failed to create directory")]
     DirectoryCreationFailed(#[source] std::io::Error),
@@ -119,6 +126,10 @@ pub enum ConfyError {
     #[cfg(feature = "yaml_conf")]
     #[error("Failed to serialize configuration data into YAML")]
     SerializeYamlError(#[source] serde_yaml::Error),
+
+    #[cfg(feature = "ron_conf")]
+    #[error("Failed to serialize configuration data into RON")]
+    SerializeRonError(#[source] ron::error::Error),
 
     #[error("Failed to write configuration file")]
     WriteConfigurationFileError(#[source] std::io::Error),
@@ -184,12 +195,17 @@ pub fn load_path<T: Serialize + DeserializeOwned + Default>(
             #[cfg(feature = "toml_conf")]
             {
                 let cfg_data = toml::from_str(&cfg_string);
-                cfg_data.map_err(ConfyError::BadTomlData)
+                return cfg_data.map_err(ConfyError::BadTomlData);
             }
             #[cfg(feature = "yaml_conf")]
             {
                 let cfg_data = serde_yaml::from_str(&cfg_string);
-                cfg_data.map_err(ConfyError::BadYamlData)
+                return cfg_data.map_err(ConfyError::BadYamlData);
+            }
+            #[cfg(feature = "ron_conf")]
+            {
+                let cfg_data = ron::from_str(&cfg_string);
+                return cfg_data.map_err(ConfyError::BadRonData);
             }
         }
         Err(ref e) if e.kind() == NotFound => {
@@ -263,6 +279,10 @@ pub fn store_path<T: Serialize>(path: impl AsRef<Path>, cfg: T) -> Result<(), Co
     #[cfg(feature = "yaml_conf")]
     {
         s = serde_yaml::to_string(&cfg).map_err(ConfyError::SerializeYamlError)?;
+    }
+    #[cfg(feature = "ron_conf")]
+    {
+        s = ron::to_string(&cfg).map_err(ConfyError::SerializeRonError)?;
     }
 
     let mut f = OpenOptions::new()


### PR DESCRIPTION
This adds the feature flag `ron_conf` to confy which allows confy to work with [ron](https://github.com/ron-rs/ron) files.

Note: I also set the rust language version in `Cargo.toml` to "2021".