### PR TITLE
use general error type for example in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ struct MyConfig {
     api_key: String,
 }
 
-fn main() -> Result<(), ::std::io::Error> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cfg: MyConfig = confy::load("my-app-name", None)?;
     dbg!(cfg);
     Ok(())


### PR DESCRIPTION
Hi, just correcting the example, which has been out-of-date since a couple of versions presumably. Had a beginner ask me about why this does not compile out of the box. Instead of boxing one could also use the confy::Error type, but I thought I would provide a general version which isn't gonna make beginners fall on their nose when they encounter anything with a different error type down the line. 