### PR TITLE
Updateto 0.6.0 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confy"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>"]
 description = "Boilerplate-free configuration management"
 license = "MIT/X11 OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 ## Confy's feature flags
-Confy can be used with either `TOML`, `YAML`, or `RON` files.
-`TOML` is the default language used with confy but any of the other languages can be used by enabling them with feature flags as shown below.
+`confy` can be used with either `TOML`, `YAML`, or `RON` files.
+`TOML` is the default language used with `confy` but any of the other languages can be used by enabling them with feature flags as shown below.
 
 Note: you can only use __one__ of these features at a time, so in order to use either of the optional features you have to disable default features.
 
-### Using yaml
-To use YAML files with confy you have to make sure you have enabled the `yaml_conf` feature and disabled both `toml_conf` and `ron_conf`.
+### Using YAML
+To use `YAML` files with `confy` you have to make sure you have enabled the `yaml_conf` feature and disabled both `toml_conf` and `ron_conf`.
 
 Enable the feature in `Cargo.toml`:
 ```toml
@@ -40,8 +40,8 @@ features = ["yaml_conf"]
 default-features = false
 ```
 
-### Using ron
-For using RON files with confy you have to make sure you have enabled the `ron_conf` feature and disabled both `toml_conf` and `yaml_conf`.
+### Using RON
+For using `RON` files with `confy` you have to make sure you have enabled the `ron_conf` feature and disabled both `toml_conf` and `yaml_conf`.
 
 Enable the feature in `Cargo.toml`:
 ```toml
@@ -54,10 +54,16 @@ default-features = false
 Information about adding context to error messages can be found at [Providing Context](https://rust-cli.github.io/book/tutorial/errors.html#providing-context)
 
 ## Breaking changes
+### Version 0.6.0
+In this version we bumped several dependencies which have had changes with some of the default (de)serialization process: 
+
+* `serde_yaml` v0.8 -> v0.9: [v0.9 release notes](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.0). There were several breaking changes to `v0.9.0` and are listed in this release tag. Especially cases where previously numbers were parsed and now return `String`. See the release notes for more details.
+* `toml` v0.5 -> v0.8: [v0.8 CHANGELOG](https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md#compatibility-1). Breaking change to how tuple variants work in `toml`, from the notes: "Serialization and deserialization of tuple variants has changed from being an array to being a table with the key being the variant name and the value being the array".
+
 ### Version 0.5.0
 * The base functions `load` and `store` have been added an optional parameter in the event multiples configurations are needed, or ones with different filename.
 * The default configuration file is now named "default-config" instead of using the application's name. Put the second argument of `load` and `store` to be the same of the first one to keep the previous configuration file.
-* It is now possible to save the configuration as toml or as yaml. The configuration's file name's extension depends on the format used.
+* It is now possible to save the configuration as `toml` or as `YAML`. The configuration's file name's extension depends on the format used.
 
 ### Version 0.4.0
 Starting with version 0.4.0 the configuration file are stored in the expected place for your system. See the [`directories`] crates for more information.


### PR DESCRIPTION
This PR updates the crate to version 0.6.0 by bumping the `Cargo.toml` version and describing the breaking changes. 

