### PR TITLE
Migrate dependency from serde_yaml to serde_yml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2021"
 ron = { version = "0.8.0", optional = true }
 directories = "5"
 serde = "^1.0"
-serde_yaml = { version = "0.9", optional = true }
+serde_yml = { version = "0.0.10", optional = true }
 thiserror = "1.0"
 toml = { version = "0.8", optional = true }
 
 [features]
 default = ["toml_conf"]
 toml_conf = ["toml"]
-yaml_conf = ["serde_yaml"]
+yaml_conf = ["serde_yml"]
 ron_conf = ["ron"]
 
 [[example]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub enum ConfyError {
 
     #[cfg(feature = "yaml_conf")]
     #[error("Bad YAML data")]
-    BadYamlData(#[source] serde_yaml::Error),
+    BadYamlData(#[source] serde_yml::Error),
 
     #[cfg(feature = "ron_conf")]
     #[error("Bad RON data")]
@@ -136,7 +136,7 @@ pub enum ConfyError {
 
     #[cfg(feature = "yaml_conf")]
     #[error("Failed to serialize configuration data into YAML")]
-    SerializeYamlError(#[source] serde_yaml::Error),
+    SerializeYamlError(#[source] serde_yml::Error),
 
     #[cfg(feature = "ron_conf")]
     #[error("Failed to serialize configuration data into RON")]
@@ -213,7 +213,7 @@ pub fn load_path<T: Serialize + DeserializeOwned + Default>(
             }
             #[cfg(feature = "yaml_conf")]
             {
-                let cfg_data = serde_yaml::from_str(&cfg_string);
+                let cfg_data = serde_yml::from_str(&cfg_string);
                 cfg_data.map_err(ConfyError::BadYamlData)
             }
             #[cfg(feature = "ron_conf")]
@@ -273,7 +273,7 @@ where
                 }
                 #[cfg(feature = "yaml_conf")]
                 {
-                    let cfg_data = serde_yaml::from_str(&cfg_string);
+                    let cfg_data = serde_yml::from_str(&cfg_string);
                     cfg_data.map_err(ConfyError::BadYamlData)
                 }
                 #[cfg(feature = "ron_conf")]
@@ -386,7 +386,7 @@ fn do_store<T: Serialize>(
     }
     #[cfg(feature = "yaml_conf")]
     {
-        s = serde_yaml::to_string(&cfg).map_err(ConfyError::SerializeYamlError)?;
+        s = serde_yml::to_string(&cfg).map_err(ConfyError::SerializeYamlError)?;
     }
     #[cfg(feature = "ron_conf")]
     {


### PR DESCRIPTION
`serde-yaml` isn't maintained as it can be seen from the [Github repo](https://github.com/dtolnay/serde-yaml), i. e., that it's archived as of March.

`serde-yml` is a fork of `serde-yaml` that's taken an independent route with different goals.

Usage of `serde-yml` may be beneficial since `serde-yaml` isn't maintained. However, I would like to hear your opinions on this PR.

I have built the library on my system and there are no breaking changes.