### PR TITLE
Incorporate Cargo Audit into CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+  pull_request:
+      types: [opened, reopened]
+  schedule:
+    - cron: '00 15 * * 1'
+
+name: Audit
+
+jobs:
+  check:
+    name: audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Install Cargo Audit
+        run: cargo install cargo-audit --locked
+        shell: bash
+      - name: Run Audit
+        run: cargo audit

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,10 @@
+[advisories]
+ignore = []
+informational_warnings = ["unmaintained"] # warn for categories of informational advisories
+severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")
+
+[output]
+deny = ["unmaintained"] # exit on error if unmaintained dependencies are found
+format = "terminal" # "terminal" (human readable report) or "json"
+quiet = false # Only print information on error
+show_tree = true # Show inverse dependency trees along with advisories (default: true)


### PR DESCRIPTION
In response to #100 setting up a `cargo audit` CI job that runs on PRs and weekly in order to keep the health of our dependencies in check.