### PR TITLE
Add missing type annotation for docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! }
 //!
 //! fn main() -> Result<(), confy::ConfyError> {
-//!     let cfg = confy::load("my-app-name", None)?;
+//!     let cfg: MyConfig = confy::load("my-app-name", None)?;
 //!     Ok(())
 //! }
 //! ```


### PR DESCRIPTION
Add missing type annotation for `MyConfig` for the docs on docs.rs.

(The sample code on README.md is already correct, so this only fixes the sample code within `lib.rs`)