### PR TITLE
ci: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Some dependencies receive important updates, but this crate doesn't seem to upgrade them very often.
I love this crate being so clean, stable and easy-to-use, but when I have eg. `directories` as a dependency as well, but on the latest version, it's bad to see how it's duplicated because of the different versions.


Checking out the [![dependency status](https://deps.rs/crate/confy/0.6.1/status.svg)](https://deps.rs/crate/confy/0.6.1), I thought adding a dependabot might make this situation better.
