### PR TITLE
add `basic_toml_conf` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,12 @@ serde = "^1.0"
 serde_yaml = { version = "0.9", optional = true }
 thiserror = "2.0"
 basic-toml = { version = "0.1.10", optional = true }
+toml = { version = "0.8", optional = true }
 
 [features]
 default = ["toml_conf"]
-toml_conf = ["basic-toml"]
+toml_conf = ["toml"]
+basic_toml_conf = ["basic-toml"]
 yaml_conf = ["serde_yaml"]
 ron_conf = ["ron"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ directories = "6"
 serde = "^1.0"
 serde_yaml = { version = "0.9", optional = true }
 thiserror = "2.0"
-toml = { version = "0.8", optional = true }
+basic-toml = { version = "0.1.10", optional = true }
 
 [features]
 default = ["toml_conf"]
-toml_conf = ["toml"]
+toml_conf = ["basic-toml"]
 yaml_conf = ["serde_yaml"]
 ron_conf = ["ron"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ const EXTENSION: &str = "ron";
 pub enum ConfyError {
     #[cfg(feature = "toml_conf")]
     #[error("Bad TOML data")]
-    BadTomlData(#[source] toml::de::Error),
+    BadTomlData(#[source] basic_toml::Error),
 
     #[cfg(feature = "yaml_conf")]
     #[error("Bad YAML data")]
@@ -132,7 +132,7 @@ pub enum ConfyError {
 
     #[cfg(feature = "toml_conf")]
     #[error("Failed to serialize configuration data into TOML")]
-    SerializeTomlError(#[source] toml::ser::Error),
+    SerializeTomlError(#[source] basic_toml::Error),
 
     #[cfg(feature = "yaml_conf")]
     #[error("Failed to serialize configuration data into YAML")]
@@ -208,7 +208,7 @@ pub fn load_path<T: Serialize + DeserializeOwned + Default>(
 
             #[cfg(feature = "toml_conf")]
             {
-                let cfg_data = toml::from_str(&cfg_string);
+                let cfg_data = basic_toml::from_str(&cfg_string);
                 cfg_data.map_err(ConfyError::BadTomlData)
             }
             #[cfg(feature = "yaml_conf")]
@@ -268,7 +268,7 @@ where
 
                 #[cfg(feature = "toml_conf")]
                 {
-                    let cfg_data = toml::from_str(&cfg_string);
+                    let cfg_data = basic_toml::from_str(&cfg_string);
                     cfg_data.map_err(ConfyError::BadTomlData)
                 }
                 #[cfg(feature = "yaml_conf")]
@@ -382,7 +382,7 @@ fn do_store<T: Serialize>(
     let s;
     #[cfg(feature = "toml_conf")]
     {
-        s = toml::to_string_pretty(&cfg).map_err(ConfyError::SerializeTomlError)?;
+        s = basic_toml::to_string(&cfg).map_err(ConfyError::SerializeTomlError)?;
     }
     #[cfg(feature = "yaml_conf")]
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,12 +61,35 @@
 //![dependencies]
 //!serde = { version = "1.0.152", features = ["derive"] } # <- Only one serde version needed (serde or serde_derive)
 //!serde_derive = "1.0.152" # <- Only one serde version needed (serde or serde_derive)
-//!confy = "^0.5"
+//!confy = "^0.6"
 //!```
 //! Updating the configuration is then done via the [`store`] function.
 //!
 //! [`store`]: fn.store.html
 //!
+//! ## Features
+//!
+//! Exactly **one** of the features has to be enabled from the following table.
+//!
+//! ### Tip
+//! to add this crate to your project with the default, toml config do the following: `cargo add confy`, otherwise do something like: `cargo add confy --no-default-features --features yaml_conf`, for more info, see [cargo docs on features]
+//! 
+//! [cargo docs on features]: https://docs.rust-lang.org/cargo/reference/resolver.html#features
+//! 
+//! feature | file format | description
+//! ------- | ----------- | -----------
+//! **default**: `toml_conf` | [toml] | considered a reasonable default, uses the standard-compliant [`toml` crate]
+//! `yaml_conf` | [yaml] | uses the [`serde_yaml` crate]
+//! `ron_conf` | [ron] | Rusty Object Notation, uses the [`ron` crate]
+//! `basic_toml_conf` | [toml] | alternative to the default `toml_conf`, instead of using the [`toml` crate], the [`basic_toml` crate] is used, in order to cut down on the number of dependencies, speed up compilation and shrink binary size. **_DISCLAIMER_**: this crate is **not** standard compliant, **nor** maintained, otherwise should work fine in most situations.
+//!
+//! [toml]: https://toml.io
+//! [`toml` crate]: https://docs.rs/toml
+//! [yaml]: https://yaml.org
+//! [`serde_yaml` crate]: https://docs.rs/serde_yaml
+//! [ron]: https://docs.rs/ron
+//! [`ron` crate]: https://docs.rs/ron
+//! [`basic_toml` crate]: https://docs.rs/basic_toml
 
 mod utils;
 use utils::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,11 +98,12 @@ use basic_toml::{
 )))]
 compile_error!(
     "Exactly one config language feature must be enabled to use \
-confy.  Please enable one of either the `toml_conf`, `yaml_conf`, \
-or `ron_conf` features."
+confy. Please enable one of either the `toml_conf`, `yaml_conf`, \
+, `ron_conf` or `toml_basic_conf` features."
 );
 
 #[cfg(any(
+    all(feature = "toml_conf", feature = "basic_toml_conf"),
     all(
         any(feature = "toml_conf", feature = "basic_toml_conf"),
         feature = "yaml_conf"


### PR DESCRIPTION
add feature to migrate from the massive `toml` dependency to it's light-weight hard fork (now unmaintained, but functional) [`basic-toml`](https://github.com/dtolnay/basic-toml). AFAIK it supports most toml syntax, except for date-time
