### PR TITLE
Add JSON support using `serde_json` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ ron = { version = "0.10.1", optional = true }
 directories = "6"
 serde = "^1.0"
 serde_yaml = { version = "0.9", optional = true }
+serde_json = { version = "1.0", optional = true }
 thiserror = "2.0"
 basic-toml = { version = "0.1.10", optional = true }
 toml = { version = "0.8", optional = true }
@@ -24,6 +25,7 @@ toml_conf = ["toml"]
 basic_toml_conf = ["basic-toml"]
 yaml_conf = ["serde_yaml"]
 ron_conf = ["ron"]
+json_conf = ["serde_json"]
 
 [[example]]
 name = "simple"

--- a/README.md
+++ b/README.md
@@ -27,13 +27,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## Confy's feature flags
 
 `confy` can be used with either `TOML`, `YAML`, or `RON` files.
-`TOML` is the default language used with `confy` but any of the other languages can be used by enabling them with feature flags as shown below.
+`TOML` is the default language used with `confy` but any of the other languages can be used by enabling them with
+feature flags as shown below.
 
-Note: you can only use __one__ of these features at a time, so in order to use either of the optional features you have to disable default features.
+Note: you can only use __one__ of these features at a time, so in order to use either of the optional features you have
+to disable default features.
 
 ### Using YAML
 
-To use `YAML` files with `confy` you have to make sure you have enabled the `yaml_conf` feature and disabled both `toml_conf` and `ron_conf`.
+To use `YAML` files with `confy` you have to make sure you have enabled the `yaml_conf` feature and disabled both
+`toml_conf` and `ron_conf`.
 
 Enable the feature in `Cargo.toml`:
 
@@ -45,7 +48,8 @@ default-features = false
 
 ### Using RON
 
-For using `RON` files with `confy` you have to make sure you have enabled the `ron_conf` feature and disabled both `toml_conf` and `yaml_conf`.
+For using `RON` files with `confy` you have to make sure you have enabled the `ron_conf` feature and disabled both
+`toml_conf` and `yaml_conf`.
 
 Enable the feature in `Cargo.toml`:
 
@@ -55,16 +59,31 @@ features = ["ron_conf"]
 default-features = false
 ```
 
+### Using JSON
+
+To use `JSON` files with `confy` you have to make sure you have enabled the `json_conf` feature and disabled both
+`toml_conf` and `ron_conf`.
+
+Enable the feature in `Cargo.toml`:
+
+```toml
+[dependencies.confy]
+features = ["json_conf"]
+default-features = false
+```
+
 ## Changing Error Messages
 
-Information about adding context to error messages can be found at [Providing Context](https://rust-cli.github.io/book/tutorial/errors.html#providing-context)
+Information about adding context to error messages can be found
+at [Providing Context](https://rust-cli.github.io/book/tutorial/errors.html#providing-context)
 
 ## Config File Location
 
-`confy` uses [ProjectDirs](https://github.com/dirs-dev/directories-rs?tab=readme-ov-file#projectdirs) to store your configuration files, the common locations for those are in the `config_dir` section, below are the common OS paths:
+`confy` uses [ProjectDirs](https://github.com/dirs-dev/directories-rs?tab=readme-ov-file#projectdirs) to store your
+configuration files, the common locations for those are in the `config_dir` section, below are the common OS paths:
 
-| Linux | macOS | Windows |
-| --- | --- | --- |
+| Linux                                                                   | macOS                                                | Windows                                             |
+|-------------------------------------------------------------------------|------------------------------------------------------|-----------------------------------------------------|
 | `$XDG_CONFIG_HOME`/`<project_path>` or `$HOME`/.config/`<project_path>` | `$HOME`/Library/Application Support/`<project_path>` | `{FOLDERID_RoamingAppData}`/`<project_path>`/config |
 
 Where the `<project_path>` will be `rs.$MY_APP_NAME`.
@@ -73,20 +92,30 @@ Where the `<project_path>` will be `rs.$MY_APP_NAME`.
 
 ### Version 0.6.0
 
-In this version we bumped several dependencies which have had changes with some of the default (de)serialization process:
+In this version we bumped several dependencies which have had changes with some of the default (de)serialization
+process:
 
-* `serde_yaml` v0.8 -> v0.9: [v0.9 release notes](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.0). There were several breaking changes to `v0.9.0` and are listed in this release tag. Especially cases where previously numbers were parsed and now return `String`. See the release notes for more details.
-* `toml` v0.5 -> v0.8: [v0.8 CHANGELOG](https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md#compatibility-1). Breaking change to how tuple variants work in `toml`, from the notes: "Serialization and deserialization of tuple variants has changed from being an array to being a table with the key being the variant name and the value being the array".
+* `serde_yaml` v0.8 -> v0.9: [v0.9 release notes](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.0). There were
+  several breaking changes to `v0.9.0` and are listed in this release tag. Especially cases where previously numbers
+  were parsed and now return `String`. See the release notes for more details.
+* `toml` v0.5 ->
+  v0.8: [v0.8 CHANGELOG](https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md#compatibility-1). Breaking
+  change to how tuple variants work in `toml`, from the notes: "Serialization and deserialization of tuple variants has
+  changed from being an array to being a table with the key being the variant name and the value being the array".
 
 ### Version 0.5.0
 
-* The base functions `load` and `store` have been added an optional parameter in the event multiples configurations are needed, or ones with different filename.
-* The default configuration file is now named "default-config" instead of using the application's name. Put the second argument of `load` and `store` to be the same of the first one to keep the previous configuration file.
-* It is now possible to save the configuration as `toml` or as `YAML`. The configuration's file name's extension depends on the format used.
+* The base functions `load` and `store` have been added an optional parameter in the event multiples configurations are
+  needed, or ones with different filename.
+* The default configuration file is now named "default-config" instead of using the application's name. Put the second
+  argument of `load` and `store` to be the same of the first one to keep the previous configuration file.
+* It is now possible to save the configuration as `toml` or as `YAML`. The configuration's file name's extension depends
+  on the format used.
 
 ### Version 0.4.0
 
-Starting with version 0.4.0 the configuration file are stored in the expected place for your system. See the [`directories`] crates for more information.
+Starting with version 0.4.0 the configuration file are stored in the expected place for your system. See the [
+`directories`] crates for more information.
 Before version 0.4.0, the configuration file was written in the current directory.
 
 [`directories`]: https://crates.io/crates/directories


### PR DESCRIPTION
Hi, not sure if this is a desired feature but something I personally will use, so opening this in case others may also find it useful. Please feel free to close or disregard if it's not something you want for the package.

Very basic changes, added a `json_format` feature. Following the existing design of the package., the JSON feature is opt-in like the other non-default features. All local tests passed on a Windows machine (executed with `cargo test --features json_format --no-default-features`).